### PR TITLE
Rewrite clock generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,3 @@ riscv = "0.4.0"
 riscv-rt = "0.4.0"
 e310x = { version = "0.3.0", features = ["rt"] }
 void = { version = "1.0.2", default-features = false }
-
-[features]
-default = ["pll", "hfxosc"]
-pll = []
-hfxosc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ e310x = { version = "0.3.0", features = ["rt"] }
 void = { version = "1.0.2", default-features = false }
 
 [features]
-default = ["pll", "hfxosc", "lfaltclk"]
+default = ["pll", "hfxosc"]
 pll = []
 hfxosc = []
-lfaltclk = []

--- a/build.rs
+++ b/build.rs
@@ -17,24 +17,7 @@ fn memory_linker_script() {
     println!("cargo:rerun-if-changed=memory.x");
 }
 
-fn external_clock_frequency() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("constants.rs");
-    let mut f = File::create(&dest_path).expect("Could not create file");
-
-    let hfxosc_freq = option_env!("BOARD_HFXOSC_FREQ").unwrap_or("16000000");
-
-    let hfxosc_freq: u32 = str::parse(hfxosc_freq)
-        .expect("Could not parse BOARD_HFXOSC_FREQ");
-
-    writeln!(&mut f, "const BOARD_HFXOSC_FREQ: u32 = {};", hfxosc_freq)
-        .expect("Could not write file");
-
-    println!("cargo:rerun-if-env-changed=BOARD_HFXOSC_FREQ");
-}
-
 fn main() {
     memory_linker_script();
-    external_clock_frequency();
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/build.rs
+++ b/build.rs
@@ -23,20 +23,14 @@ fn external_clock_frequency() {
     let mut f = File::create(&dest_path).expect("Could not create file");
 
     let hfxosc_freq = option_env!("BOARD_HFXOSC_FREQ").unwrap_or("16000000");
-    let lfaltclk_freq = option_env!("BOARD_LFALTCLK_FREQ").unwrap_or("32768");
 
     let hfxosc_freq: u32 = str::parse(hfxosc_freq)
         .expect("Could not parse BOARD_HFXOSC_FREQ");
-    let lfaltclk_freq: u32 = str::parse(lfaltclk_freq)
-        .expect("Could not parse BOARD_LFALTCLK_FREQ");
 
     writeln!(&mut f, "const BOARD_HFXOSC_FREQ: u32 = {};", hfxosc_freq)
         .expect("Could not write file");
-    writeln!(&mut f, "const BOARD_LFALTCLK_FREQ: u32 = {};", lfaltclk_freq)
-        .expect("Could not write file");
 
     println!("cargo:rerun-if-env-changed=BOARD_HFXOSC_FREQ");
-    println!("cargo:rerun-if-env-changed=BOARD_LFALTCLK_FREQ");
 }
 
 fn main() {

--- a/src/clint.rs
+++ b/src/clint.rs
@@ -25,9 +25,7 @@ pub trait ClintExt {
 }
 
 /// Opaque MTIME register
-pub struct MTIME {
-    _0: (),
-}
+pub struct MTIME;
 
 impl MTIME {
     /// Read mtime register.
@@ -180,7 +178,7 @@ impl ClintExt for CLINT {
     fn split(self) -> ClintParts {
         ClintParts {
             mtimecmp: MTIMECMP { _0: () },
-            mtime: MTIME { _0: () },
+            mtime: MTIME,
             mcycle: MCYCLE { _0: () },
             minstret: MINSTRET { _0: () },
             mtimer: MTIMER { _0: () },

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -372,6 +372,13 @@ impl Clocks {
         self.coreclk
     }
 
+    /// Returns the frozen tlclk frequency
+    pub fn tlclk(&self) -> Hertz {
+        // For the FE310-G000, the TileLink bus clock (tlclk) is fixed to be
+        // the same as the processor core clock (coreclk)
+        self.coreclk
+    }
+
     /// Returns the frozen lfclk frequency
     pub fn lfclk(&self) -> Hertz {
         self.lfclk

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -67,7 +67,7 @@ macro_rules! hal {
                     TX: TxPin<$UARTX>,
                     RX: RxPin<$UARTX>,
                 {
-                    let div = clocks.coreclk().0 / baud_rate.0 + 1;
+                    let div = clocks.tlclk().0 / baud_rate.0 + 1;
                     unsafe { uart.div.write(|w| w.bits(div)); }
 
                     uart.txctrl.write(|w| w.enable().bit(true));


### PR DESCRIPTION
Now it's possible to set arbitrary clock frequencies both for external clocks (without environment variables) and `coreclk`.