### PR TITLE
Fix Delay and add Sleep as compatible option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e310x-hal"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["David Craven <david@craven.ch>"]
 repository = "https://github.com/riscv-rust/e310x-hal"
 categories = ["embedded", "hardware-support", "no-std"]
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
-nb = "0.1.1"
-riscv = "0.5.0"
+nb = "0.1.2"
+riscv = "0.5.2"
 e310x = { version = "0.5.1", features = ["rt"] }
 
 [features]

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -2,7 +2,7 @@
 
 use embedded_hal::blocking::delay::DelayMs;
 use crate::clint::{MTIME, MTIMECMP};
-use crate::time::Hertz;
+use crate::clock::Clocks;
 use riscv::register::{mie, mip};
 
 /// Machine timer (mtime) as a busyloop delay provider
@@ -45,9 +45,9 @@ pub struct Sleep {
 
 impl Sleep {
     /// Constructs a delay provider using mtimecmp register to sleep
-    pub fn new(mtimecmp: MTIMECMP, clock_freq: Hertz) -> Self {
+    pub fn new(mtimecmp: MTIMECMP, clocks: Clocks) -> Self {
         Sleep {
-            clock_freq: clock_freq.0,
+            clock_freq: clocks.lfclk().0,
             mtimecmp,
         }
     }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,9 +1,10 @@
 //! # Delays
 
 use embedded_hal::blocking::delay::DelayMs;
-use crate::clint::MTIME;
+use crate::clint::{MTIME, MTIMECMP};
+use riscv::register::{mie, mip};
 
-/// Machine timer (mtime) as a delay provider
+/// Machine timer (mtime) as a busyloop delay provider
 pub struct Delay;
 
 impl Delay {
@@ -30,6 +31,60 @@ impl DelayMs<u16> for Delay {
 }
 
 impl DelayMs<u8> for Delay {
+    fn delay_ms(&mut self, ms: u8) {
+        self.delay_ms(u32::from(ms));
+    }
+}
+
+/// Machine timer (mtime) as a sleep delay provider using mtimecmp
+pub struct Sleep {
+    mtimecmp: MTIMECMP
+}
+
+impl Sleep {
+    /// Constructs a delay provider using mtimecmp register to sleep
+    pub fn new(mtimecmp: MTIMECMP) -> Self {
+        unsafe {
+            mie::set_mtimer();
+        }
+
+        Sleep {
+            mtimecmp
+        }
+    }
+}
+
+impl DelayMs<u32> for Sleep {
+    fn delay_ms(&mut self, ms: u32) {
+        let ticks = (ms as u64) * 65536 / 1000;
+        let t = MTIME.mtime() + ticks;
+
+        self.mtimecmp.set_mtimecmp(t);
+        
+        // Wait For Interrupt will put CPU to sleep until an interrupt hits
+        // in our case when internal timer mtime value >= mtimecmp value
+        // after which empty handler gets called and we go into the
+        // next iteration of this loop
+        loop {
+            unsafe {
+                riscv::asm::wfi();
+            }
+
+            // check if we got the right interrupt cause, otherwise just loop back to wfi
+            if mip::read().mtimer() {
+                break;
+            }
+        }
+    }
+}
+
+impl DelayMs<u16> for Sleep {
+    fn delay_ms(&mut self, ms: u16) {
+        self.delay_ms(u32::from(ms));
+    }
+}
+
+impl DelayMs<u8> for Sleep {
     fn delay_ms(&mut self, ms: u8) {
         self.delay_ms(u32::from(ms));
     }


### PR DESCRIPTION
This PR does 3 things:

1. Fixes Delay ticks calculation (for default clock)
2. Adds Sleep as DelayMs compatible implementation for delays using mtimecmp and wfi()
3. Bumps version + dependency updates