### PR TITLE
Update to latest e310x dependency + SPI CS mode fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e310x-hal"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["David Craven <david@craven.ch>"]
 repository = "https://github.com/riscv-rust/e310x-hal"
 categories = ["embedded", "hardware-support", "no-std"]
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 nb = "0.1.2"
-riscv = "0.5.2"
-e310x = { version = "0.5.1", features = ["rt"] }
+riscv = "0.5.3"
+e310x = { version = "0.6.0", features = ["rt"] }
 
 [features]
 g002 = ["e310x/g002"]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -112,6 +112,7 @@ pub struct Spi<SPI, PINS> {
 
 impl<SPI: SpiX, PINS> Spi<SPI, PINS> {
     /// Configures the SPI peripheral to operate in full duplex master mode
+    /// Defaults to using AUTO CS in FRAME mode if PINS configuration allows it
     pub fn new(spi: SPI, pins: PINS, mode: Mode, freq: Hertz, clocks: Clocks) -> Self
     where
         PINS: Pins<SPI>

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -286,15 +286,13 @@ impl<SPI: SpiX, PINS> embedded_hal::blocking::spi::Write<u8> for Spi<SPI, PINS> 
     type Error = Infallible;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        // Save watermark levels and csmode
+        // Save watermark levels
         let txmark = self.spi.txmark.read().value().bits();
         let rxmark = self.spi.rxmark.read().value().bits();
-        let csmode = self.spi.csmode.read().bits();
 
-        // Set watermark levels and csmode
+        // Set watermark levels
         self.spi.txmark.write(|w| unsafe { w.value().bits(1) });
         self.spi.rxmark.write(|w| unsafe { w.value().bits(0) });
-        self.spi.csmode.write(|w| unsafe { w.bits(csmode) });
 
         // Ensure that RX FIFO is empty
         while self.spi.ip.read().rxwm().bit_is_set() {
@@ -316,10 +314,9 @@ impl<SPI: SpiX, PINS> embedded_hal::blocking::spi::Write<u8> for Spi<SPI, PINS> 
             }
         }
 
-        // Restore watermark levels and csmode
+        // Restore watermark levels
         self.spi.txmark.write(|w| unsafe { w.value().bits(txmark) });
         self.spi.rxmark.write(|w| unsafe { w.value().bits(rxmark) });
-        self.spi.csmode.write(|w| unsafe { w.bits(csmode) });
 
         Ok(())
     }


### PR DESCRIPTION
Updates to latest e310x dependency with riscv-rt and adds SPI AUTO CS mode fix with optional mode selects.