### PR TITLE
fixed `PeripheralAccess::value()`

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -75,7 +75,7 @@ trait PeripheralAccess {
 
     fn value(index: usize) -> bool {
         let p = Self::peripheral();
-        (p.value.read().bits() >> (index & 31)) != 0
+        (p.value.read().bits() >> (index & 31) & 1) != 0
     }
 
     fn set_input_en(index: usize, bit: bool) {


### PR DESCRIPTION
The lack of `& 1` caused using pins other than the highest numbered one
as an input to not work correctly due to misinterpreting garbage bits as
setting the pin in the high state. `&`ing with `1` solves this problem
by zeroing out bits that should be ignored.