### PR TITLE
fix DelayUs using millisecond variants by typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fixed `e310x-hal::delay::Delay` call typo to `delay_ms`
+
 ## [v0.9.2] - 2021-07-17
 
 ### Changed

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -19,7 +19,7 @@ impl Delay {
 
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
-        let ticks = (us as u64) * TICKS_PER_SECOND / 1000_000;
+        let ticks = (us as u64) * TICKS_PER_SECOND / 1_000_000;
 
         let mtime = MTIME;
         let t = mtime.mtime() + ticks;
@@ -39,14 +39,14 @@ impl DelayUs<i32> for Delay {
 impl DelayUs<u16> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u16) {
-        self.delay_ms(u32::from(us));
+        self.delay_us(u32::from(us));
     }
 }
 
 impl DelayUs<u8> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u8) {
-        self.delay_ms(u32::from(us));
+        self.delay_us(u32::from(us));
     }
 }
 


### PR DESCRIPTION
I'm afraid I made a :hankey: on my last `DelayUs` PR and called `delay_ms` on the non `u32` variants of `DelayUs`

This fixes it. I'll release patched version after.