### PR TITLE
Fix StatefulOutputPin

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -95,6 +95,11 @@ trait PeripheralAccess {
         atomic_set_bit(r, index, bit);
     }
 
+    fn output_value(index: usize) -> bool {
+        let p = Self::peripheral();
+        (p.output_val.read().bits() >> (index & 31) & 1) != 0
+    }
+
     fn toggle_pin(index: usize) {
         let p = Self::peripheral();
         let r: &AtomicU32 = unsafe { core::mem::transmute(&p.output_val) };
@@ -290,7 +295,7 @@ macro_rules! gpio {
 
                 impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> {
                     fn is_set_high(&self) -> Result<bool, Infallible> {
-                        Ok($GPIOX::input_value(Self::INDEX))
+                        Ok($GPIOX::output_value(Self::INDEX))
                     }
 
                     fn is_set_low(&self) -> Result<bool, Infallible> {


### PR DESCRIPTION
According to https://docs.rs/embedded-hal/latest/embedded_hal/digital/v2/trait.StatefulOutputPin.html,
the functions in StatefulOutputPin should not read the actual electrical
value of the pin, but the current state of the output driver.

The fe310 manual states: "Reading the output_val register returns the
written value. Reading the input_val register returns the actual value
of the pin gated by input_en."

So the right thing to do here is to read the corresponding bit in the
output register.

*NOTE*: I don't have hardware to actually test this fix.