### PR TITLE
embedded-hal v1.0.0-alpha.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.42.0
-        rust: [nightly, stable, 1.42.0]
+        # All generated code should be running on stable now, MRSV is 1.59.0
+        rust: [nightly, stable, 1.59.0]
 
         include:
           # Nightly is only for reference and allowed to fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Updated to support `embedded-hal` version `1.0.0-alpha.7`
+
 - Refactored `e310x-hal::spi` module, splitting the abstraction into `SpiBus` and `SpiExclusiveDevice/SpiSharedDevice` to allow multiple devices on a single SPI bus to co-exist
 
 ## [v0.9.3] - 2021-08-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e310x-hal"
-version = "0.9.3"
+version = "0.10.0-alpha.1"
 authors = ["David Craven <david@craven.ch>"]
 repository = "https://github.com/riscv-rust/e310x-hal"
 categories = ["embedded", "hardware-support", "no-std"]
@@ -10,10 +10,10 @@ license = "ISC"
 edition = "2018"
 
 [dependencies]
-embedded-hal = { version = "0.2.6", features = ["unproven"] }
+embedded-hal = "=1.0.0-alpha.7"
 nb = "1.0.0"
-riscv = "0.7.0"
-e310x = { version = "0.9.0", features = ["rt"] }
+riscv = "0.8.0"
+e310x = { version = "0.9.1", features = ["rt"] }
 
 [features]
 g002 = ["e310x/g002"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "ISC"
 edition = "2018"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.7"
+embedded-hal = "=1.0.0-alpha.8"
 nb = "1.0.0"
 riscv = "0.9.0-alpha.1"
 e310x = { version = "0.9.1", features = ["rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 embedded-hal = "=1.0.0-alpha.7"
 nb = "1.0.0"
-riscv = "0.8.0"
+riscv = "0.9.0-alpha.1"
 e310x = { version = "0.9.1", features = ["rt"] }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.42.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.59.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -142,7 +142,8 @@ macro_rules! gpio {
             use core::marker::PhantomData;
             use core::convert::Infallible;
 
-            use embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin,
+            use embedded_hal::digital::ErrorType;
+            use embedded_hal::digital::blocking::{InputPin, OutputPin, StatefulOutputPin,
                                ToggleableOutputPin};
             use e310x::$GPIOX;
             use super::{Unknown, IOF0, IOF1, Drive, Floating, GpioExt, Input, Invert,
@@ -275,9 +276,11 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> InputPin for $PXi<Input<MODE>> {
+                impl<MODE> ErrorType for $PXi<Input<MODE>> {
                     type Error = Infallible;
+                }
 
+                impl<MODE> InputPin for $PXi<Input<MODE>> {
                     fn is_high(&self) -> Result<bool, Infallible> {
                         Ok($GPIOX::input_value(Self::INDEX))
 
@@ -298,9 +301,11 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> OutputPin for $PXi<Output<MODE>> {
+                impl<MODE> ErrorType for $PXi<Output<MODE>> {
                     type Error = Infallible;
+                }
 
+                impl<MODE> OutputPin for $PXi<Output<MODE>> {
                     fn set_high(&mut self) -> Result<(), Infallible> {
                         $GPIOX::set_output_value(Self::INDEX, true);
                         Ok(())
@@ -313,8 +318,6 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> ToggleableOutputPin for $PXi<Output<MODE>> {
-                    type Error = Infallible;
-
                     /// Toggles the pin state.
                     fn toggle(&mut self) -> Result<(), Infallible> {
                         $GPIOX::toggle_pin(Self::INDEX);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -16,7 +16,8 @@ use crate::time::Bps;
 use core::mem;
 use core::ops::Deref;
 use e310x::{i2c0, I2C0};
-use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
+use embedded_hal::i2c::blocking::{self as i2c, Operation};
+use embedded_hal::i2c::{ErrorKind, ErrorType, NoAcknowledgeSource};
 
 /// SDA pin - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait SdaPin<I2C> {}
@@ -25,19 +26,6 @@ pub unsafe trait SclPin<I2C> {}
 
 unsafe impl<T> SdaPin<I2C0> for gpio0::Pin12<IOF0<T>> {}
 unsafe impl<T> SclPin<I2C0> for gpio0::Pin13<IOF0<T>> {}
-
-/// I2C error
-#[derive(Debug, Eq, PartialEq)]
-pub enum Error {
-    /// Invalid peripheral state
-    InvalidState,
-
-    /// Arbitration lost
-    ArbitrationLost,
-
-    /// No ACK received
-    NoAck,
-}
 
 /// Transmission speed
 pub enum Speed {
@@ -121,7 +109,7 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> I2c<I2C, PINS> {
     }
 
     fn read_sr(&self) -> i2c0::sr::R {
-        unsafe { mem::transmute(self.i2c.sr().read()) }
+        self.i2c.sr().read()
     }
 
     fn write_byte(&self, byte: u8) {
@@ -132,7 +120,7 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> I2c<I2C, PINS> {
         self.i2c.txr_rxr.read().data().bits()
     }
 
-    fn wait_for_interrupt(&self) -> Result<(), Error> {
+    fn wait_for_interrupt(&self) -> Result<(), ErrorKind> {
         loop {
             let sr = self.read_sr();
 
@@ -141,7 +129,7 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> I2c<I2C, PINS> {
                 self.write_cr(|w| w.sto().set_bit());
                 self.wait_for_complete();
 
-                return Err(Error::ArbitrationLost);
+                return Err(ErrorKind::ArbitrationLoss);
             }
 
             if sr.if_().bit_is_set() {
@@ -153,11 +141,11 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> I2c<I2C, PINS> {
         }
     }
 
-    fn wait_for_read(&self) -> Result<(), Error> {
+    fn wait_for_read(&self) -> Result<(), ErrorKind> {
         self.wait_for_interrupt()
     }
 
-    fn wait_for_write(&self) -> Result<(), Error> {
+    fn wait_for_write(&self) -> Result<(), ErrorKind> {
         self.wait_for_interrupt()?;
 
         if self.read_sr().rx_ack().bit_is_set() {
@@ -165,7 +153,7 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> I2c<I2C, PINS> {
             self.write_cr(|w| w.sto().set_bit());
             self.wait_for_complete();
 
-            return Err(Error::NoAck);
+            return Err(ErrorKind::NoAcknowledge(NoAcknowledgeSource::Unknown));
         }
 
         Ok(())
@@ -179,14 +167,16 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> I2c<I2C, PINS> {
 const FLAG_READ: u8 = 1;
 const FLAG_WRITE: u8 = 0;
 
-impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> Read for I2c<I2C, PINS> {
-    type Error = Error;
+impl<I2C, PINS> ErrorType for I2c<I2C, PINS> {
+    type Error = ErrorKind;
+}
 
+impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> i2c::I2c for I2c<I2C, PINS> {
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
         self.reset();
 
         if self.read_sr().busy().bit_is_set() {
-            return Err(Error::InvalidState);
+            return Err(ErrorKind::Other);
         }
 
         // Write address + R
@@ -212,16 +202,12 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> Read for I2c<I2C, PINS> {
         }
         Ok(())
     }
-}
-
-impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> Write for I2c<I2C, PINS> {
-    type Error = Error;
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         self.reset();
 
         if self.read_sr().busy().bit_is_set() {
-            return Err(Error::InvalidState);
+            return Err(ErrorKind::Other);
         }
 
         // Write address + W
@@ -244,10 +230,39 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> Write for I2c<I2C, PINS> {
         }
         Ok(())
     }
-}
 
-impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> WriteRead for I2c<I2C, PINS> {
-    type Error = Error;
+    fn write_iter<B: IntoIterator<Item = u8>>(
+        &mut self,
+        address: u8,
+        bytes: B,
+    ) -> Result<(), Self::Error> {
+        self.reset();
+
+        if self.read_sr().busy().bit_is_set() {
+            return Err(ErrorKind::Other);
+        }
+
+        // Write address + W
+        self.write_byte((address << 1) + FLAG_WRITE);
+
+        // Generate start condition and write command
+        self.write_cr(|w| w.sta().set_bit().wr().set_bit());
+        self.wait_for_write()?;
+
+        // Write bytes
+        let mut bytes = bytes.into_iter().peekable();
+        while let Some(byte) = bytes.next() {
+            self.write_byte(byte);
+
+            if bytes.peek().is_some() {
+                self.write_cr(|w| w.wr().set_bit()); // all others
+            } else {
+                self.write_cr(|w| w.wr().set_bit().sto().set_bit()); // last one
+            }
+            self.wait_for_write()?;
+        }
+        Ok(())
+    }
 
     fn write_read(
         &mut self,
@@ -258,7 +273,7 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> WriteRead for I2c<I2C, PINS
         self.reset();
 
         if self.read_sr().busy().bit_is_set() {
-            return Err(Error::InvalidState);
+            return Err(ErrorKind::Other);
         }
 
         if !bytes.is_empty() && buffer.is_empty() {
@@ -307,5 +322,206 @@ impl<I2C: Deref<Target = i2c0::RegisterBlock>, PINS> WriteRead for I2c<I2C, PINS
 
             Ok(())
         }
+    }
+
+    fn write_iter_read<B: IntoIterator<Item = u8>>(
+        &mut self,
+        address: u8,
+        bytes: B,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        self.reset();
+
+        if self.read_sr().busy().bit_is_set() {
+            return Err(ErrorKind::Other);
+        }
+
+        let mut bytes = bytes.into_iter().peekable();
+        if bytes.peek().is_some() && buffer.is_empty() {
+            self.write_iter(address, bytes)
+        } else if !buffer.is_empty() && bytes.peek().is_none() {
+            self.read(address, buffer)
+        } else if bytes.peek().is_none() && buffer.is_empty() {
+            Ok(())
+        } else {
+            // Write address + W
+            self.write_byte((address << 1) + FLAG_WRITE);
+
+            // Generate start condition and write command
+            self.write_cr(|w| w.sta().set_bit().wr().set_bit());
+            self.wait_for_write()?;
+
+            // Write bytes
+            for byte in bytes {
+                self.write_byte(byte);
+
+                self.write_cr(|w| w.wr().set_bit());
+                self.wait_for_write()?;
+            }
+
+            // Write address + R
+            self.write_byte((address << 1) + FLAG_READ);
+
+            // Generate repeated start condition and write command
+            self.write_cr(|w| w.sta().set_bit().wr().set_bit());
+            self.wait_for_write()?;
+
+            // Read bytes
+            let buffer_len = buffer.len();
+            for (i, byte) in buffer.iter_mut().enumerate() {
+                if i != buffer_len - 1 {
+                    // W + ACK
+                    self.write_cr(|w| w.rd().set_bit().ack().clear_bit());
+                } else {
+                    // W + NACK + STOP
+                    self.write_cr(|w| w.rd().set_bit().ack().set_bit().sto().set_bit());
+                }
+                self.wait_for_read()?;
+
+                *byte = self.read_byte();
+            }
+
+            Ok(())
+        }
+    }
+
+    fn transaction<'a>(
+        &mut self,
+        address: u8,
+        operations: &mut [Operation<'a>],
+    ) -> Result<(), Self::Error> {
+        self.reset();
+
+        if self.read_sr().busy().bit_is_set() {
+            return Err(ErrorKind::Other);
+        }
+
+        let last_op = operations.len() - 1;
+        let mut last_flag = 0xFF;
+        for (i, op) in operations.iter_mut().enumerate() {
+            match op {
+                Operation::Read(bytes) => {
+                    if last_flag != FLAG_READ {
+                        // Write address + R
+                        self.write_byte((address << 1) + FLAG_READ);
+
+                        // Generate repeated start condition and write command
+                        self.write_cr(|w| w.sta().set_bit().wr().set_bit());
+                        self.wait_for_write()?;
+                        last_flag = FLAG_READ;
+                    }
+
+                    // Read bytes
+                    let last_byte = bytes.len() - 1;
+                    for (j, byte) in bytes.iter_mut().enumerate() {
+                        if i != last_op || j != last_byte {
+                            // W + ACK
+                            self.write_cr(|w| w.rd().set_bit().ack().clear_bit());
+                        } else {
+                            // W + NACK + STOP
+                            self.write_cr(|w| w.rd().set_bit().ack().set_bit().sto().set_bit());
+                        }
+                        self.wait_for_read()?;
+
+                        *byte = self.read_byte();
+                    }
+                }
+                Operation::Write(bytes) => {
+                    if last_flag != FLAG_WRITE {
+                        // Write address + W
+                        self.write_byte((address << 1) + FLAG_WRITE);
+
+                        // Generate start condition and write command
+                        self.write_cr(|w| w.sta().set_bit().wr().set_bit());
+                        self.wait_for_write()?;
+                        last_flag = FLAG_WRITE;
+                    }
+
+                    // Write bytes
+                    for (j, byte) in bytes.iter().enumerate() {
+                        self.write_byte(*byte);
+
+                        if i != last_op || j != bytes.len() - 1 {
+                            self.write_cr(|w| w.wr().set_bit());
+                        } else {
+                            self.write_cr(|w| w.wr().set_bit().sto().set_bit());
+                        }
+                        self.wait_for_write()?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn transaction_iter<'a, O: IntoIterator<Item = Operation<'a>>>(
+        &mut self,
+        address: u8,
+        operations: O,
+    ) -> Result<(), Self::Error> {
+        self.reset();
+
+        if self.read_sr().busy().bit_is_set() {
+            return Err(ErrorKind::Other);
+        }
+
+        let mut last_flag = 0xFF;
+        let mut operations = operations.into_iter().peekable();
+        while let Some(op) = operations.next() {
+            match op {
+                Operation::Read(bytes) => {
+                    if last_flag != FLAG_READ {
+                        // Write address + R
+                        self.write_byte((address << 1) + FLAG_READ);
+
+                        // Generate repeated start condition and write command
+                        self.write_cr(|w| w.sta().set_bit().wr().set_bit());
+                        self.wait_for_write()?;
+                        last_flag = FLAG_READ;
+                    }
+
+                    // Read bytes
+                    let last_byte = bytes.len() - 1;
+                    for (j, byte) in bytes.iter_mut().enumerate() {
+                        if operations.peek().is_some() || j != last_byte {
+                            // W + ACK
+                            self.write_cr(|w| w.rd().set_bit().ack().clear_bit());
+                        } else {
+                            // W + NACK + STOP
+                            self.write_cr(|w| w.rd().set_bit().ack().set_bit().sto().set_bit());
+                        }
+                        self.wait_for_read()?;
+
+                        *byte = self.read_byte();
+                    }
+                }
+                Operation::Write(bytes) => {
+                    if last_flag != FLAG_WRITE {
+                        // Write address + W
+                        self.write_byte((address << 1) + FLAG_WRITE);
+
+                        // Generate start condition and write command
+                        self.write_cr(|w| w.sta().set_bit().wr().set_bit());
+                        self.wait_for_write()?;
+                        last_flag = FLAG_WRITE;
+                    }
+
+                    // Write bytes
+                    for (j, byte) in bytes.iter().enumerate() {
+                        self.write_byte(*byte);
+
+                        if operations.peek().is_some() || j != bytes.len() - 1 {
+                            self.write_cr(|w| w.wr().set_bit());
+                        } else {
+                            self.write_cr(|w| w.wr().set_bit().sto().set_bit());
+                        }
+                        self.wait_for_write()?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,9 +7,4 @@ pub use crate::rtc::RtcExt as _e310x_hal_rtc_RtcExt;
 pub use crate::stdout::Write as _e310x_hal_stdout_Write;
 pub use crate::time::U32Ext as _e310x_hal_time_U32Ext;
 pub use crate::wdog::WdogExt as _e310x_hal_wdog_WdogExt;
-pub use embedded_hal::digital::v2::{
-    InputPin as _embedded_hal_digital_v2_InputPin, OutputPin as _embedded_hal_digital_v2_OutputPin,
-    StatefulOutputPin as _embedded_hal_digital_v2_StatefulOutputPin,
-    ToggleableOutputPin as _embedded_hal_digital_v2_ToggleableOutputPin,
-};
-pub use embedded_hal::prelude::*;
+pub use embedded_hal::digital::blocking::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -24,7 +24,7 @@
 //! - Interrupt::QSPI2
 //!
 //! # Exclusive Bus usage example
-//!```
+//!```ignore
 //! let pins = (mosi, miso, sck, cs0);
 //! let spi_bus = SpiBus::new(p.QSPI1, pins);
 //!
@@ -35,7 +35,7 @@
 //!```
 //!
 //! # Shared Bus usage example
-//!```
+//!```ignore
 //! let pins = (mosi, miso, sck);
 //! let spi_bus = SpiBus::shared(p.QSPI1, pins);
 //!

--- a/src/spi/bus.rs
+++ b/src/spi/bus.rs
@@ -1,7 +1,7 @@
-use core::convert::Infallible;
-use embedded_hal::blocking::spi::Operation;
-pub use embedded_hal::blocking::spi::{Transfer, Write, WriteIter};
-pub use embedded_hal::spi::{FullDuplex, Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+use embedded_hal::spi::blocking::Operation;
+pub use embedded_hal::spi::blocking::{Read, Transfer, TransferInplace, Write, WriteIter};
+pub use embedded_hal::spi::nb::FullDuplex;
+pub use embedded_hal::spi::{ErrorKind, Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 
 use nb;
 
@@ -103,7 +103,7 @@ where
 
     // ex-traits now only accessible via devices
 
-    pub(crate) fn read(&mut self) -> nb::Result<u8, Infallible> {
+    pub(crate) fn read(&mut self) -> nb::Result<u8, ErrorKind> {
         let rxdata = self.spi.rxdata.read();
 
         if rxdata.empty().bit_is_set() {
@@ -113,7 +113,7 @@ where
         }
     }
 
-    pub(crate) fn send(&mut self, byte: u8) -> nb::Result<(), Infallible> {
+    pub(crate) fn send(&mut self, byte: u8) -> nb::Result<(), ErrorKind> {
         let txdata = self.spi.txdata.read();
 
         if txdata.full().bit_is_set() {
@@ -124,7 +124,35 @@ where
         }
     }
 
-    pub(crate) fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Infallible> {
+    pub(crate) fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), ErrorKind> {
+        let mut iwrite = 0;
+        let mut iread = 0;
+
+        // Ensure that RX FIFO is empty
+        self.wait_for_rxfifo();
+
+        while iwrite < write.len() || iread < read.len() {
+            if iwrite < write.len() && self.spi.txdata.read().full().bit_is_clear() {
+                let byte = write.get(iwrite).unwrap_or(&0);
+                iwrite += 1;
+                self.spi.txdata.write(|w| unsafe { w.data().bits(*byte) });
+            }
+
+            if iread < iwrite {
+                let data = self.spi.rxdata.read();
+                if data.empty().bit_is_clear() {
+                    if let Some(d) = read.get_mut(iread) {
+                        *d = data.data().bits()
+                    };
+                    iread += 1;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn transfer_inplace(&mut self, words: &mut [u8]) -> Result<(), ErrorKind> {
         let mut iwrite = 0;
         let mut iread = 0;
 
@@ -147,35 +175,10 @@ where
             }
         }
 
-        Ok(words)
-    }
-
-    pub(crate) fn write(&mut self, words: &[u8]) -> Result<(), Infallible> {
-        let mut iwrite = 0;
-        let mut iread = 0;
-
-        // Ensure that RX FIFO is empty
-        self.wait_for_rxfifo();
-
-        while iwrite < words.len() || iread < words.len() {
-            if iwrite < words.len() && self.spi.txdata.read().full().bit_is_clear() {
-                let byte = unsafe { words.get_unchecked(iwrite) };
-                iwrite += 1;
-                self.spi.txdata.write(|w| unsafe { w.data().bits(*byte) });
-            }
-
-            if iread < iwrite {
-                // Read and discard byte, if any
-                if self.spi.rxdata.read().empty().bit_is_clear() {
-                    iread += 1;
-                }
-            }
-        }
-
         Ok(())
     }
 
-    pub(crate) fn write_iter<WI>(&mut self, words: WI) -> Result<(), Infallible>
+    pub(crate) fn write_iter<WI>(&mut self, words: WI) -> Result<(), ErrorKind>
     where
         WI: IntoIterator<Item = u8>,
     {
@@ -211,14 +214,20 @@ where
     pub(crate) fn exec<'op>(
         &mut self,
         operations: &mut [Operation<'op, u8>],
-    ) -> Result<(), Infallible> {
+    ) -> Result<(), ErrorKind> {
         for op in operations {
             match op {
-                Operation::Transfer(words) => {
-                    self.transfer(words)?;
+                Operation::Read(words) => {
+                    self.transfer(words, &[])?;
                 }
                 Operation::Write(words) => {
-                    self.write(words)?;
+                    self.transfer(&mut [], words)?;
+                }
+                Operation::Transfer(read_words, write_words) => {
+                    self.transfer(read_words, write_words)?;
+                }
+                Operation::TransferInplace(words) => {
+                    self.transfer_inplace(words)?;
                 }
             }
         }

--- a/src/spi/bus.rs
+++ b/src/spi/bus.rs
@@ -131,7 +131,8 @@ where
         // Ensure that RX FIFO is empty
         self.wait_for_rxfifo();
 
-        while iwrite < write.len() || iread < read.len() {
+        // go through entire write buffer and read back (even if read buffer is empty)
+        while iwrite < write.len() || iread < write.len() {
             if iwrite < write.len() && self.spi.txdata.read().full().bit_is_clear() {
                 let byte = write.get(iwrite).unwrap_or(&0);
                 iwrite += 1;

--- a/src/spi/bus.rs
+++ b/src/spi/bus.rs
@@ -141,7 +141,7 @@ where
     SPI: SpiX,
 {
     fn flush(&mut self) -> Result<(), Self::Error> {
-        // unnecessary
+        // unnecessary as all Bus operations always wait for reads to finish
 
         Ok(())
     }

--- a/src/spi/exclusive_device.rs
+++ b/src/spi/exclusive_device.rs
@@ -1,8 +1,7 @@
-use core::convert::Infallible;
-
-use embedded_hal::{
-    blocking::spi::{Operation, Transactional, Transfer, Write, WriteIter},
-    spi::FullDuplex,
+use embedded_hal::spi::{
+    blocking::{Operation, Transactional, Transfer, TransferInplace, Write, WriteIter},
+    nb::FullDuplex,
+    ErrorKind, ErrorType,
 };
 
 use crate::spi::SpiConfig;
@@ -36,61 +35,71 @@ where
     }
 }
 
-impl<SPI, PINS> FullDuplex<u8> for SpiExclusiveDevice<SPI, PINS>
+impl<SPI, PINS> ErrorType for SpiExclusiveDevice<SPI, PINS> {
+    type Error = ErrorKind;
+}
+
+impl<SPI, PINS> FullDuplex for SpiExclusiveDevice<SPI, PINS>
 where
     SPI: SpiX,
     PINS: Pins<SPI>,
 {
-    type Error = Infallible;
-
-    fn read(&mut self) -> nb::Result<u8, Infallible> {
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.bus.read()
     }
 
-    fn send(&mut self, byte: u8) -> nb::Result<(), Infallible> {
+    fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
         self.bus.send(byte)
     }
 }
 
-impl<SPI, PINS> Transfer<u8> for SpiExclusiveDevice<SPI, PINS>
+impl<SPI, PINS> Transfer for SpiExclusiveDevice<SPI, PINS>
 where
     SPI: SpiX,
     PINS: Pins<SPI>,
 {
-    type Error = Infallible;
-
-    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
         self.bus.start_frame();
-        let result = self.bus.transfer(words);
+        let result = self.bus.transfer(read, write);
         self.bus.end_frame();
 
         result
     }
 }
 
-impl<SPI, PINS> Write<u8> for SpiExclusiveDevice<SPI, PINS>
+impl<SPI, PINS> TransferInplace for SpiExclusiveDevice<SPI, PINS>
 where
     SPI: SpiX,
     PINS: Pins<SPI>,
 {
-    type Error = Infallible;
+    fn transfer_inplace<'w>(&mut self, words: &'w mut [u8]) -> Result<(), Self::Error> {
+        self.bus.start_frame();
+        let result = self.bus.transfer_inplace(words);
+        self.bus.end_frame();
 
+        result
+    }
+}
+
+impl<SPI, PINS> Write for SpiExclusiveDevice<SPI, PINS>
+where
+    SPI: SpiX,
+    PINS: Pins<SPI>,
+{
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
         self.bus.start_frame();
-        let result = self.bus.write(words);
+        let result = self.bus.transfer(&mut [], words);
         self.bus.end_frame();
 
         result
     }
 }
 
-impl<SPI, PINS> WriteIter<u8> for SpiExclusiveDevice<SPI, PINS>
+impl<SPI, PINS> WriteIter for SpiExclusiveDevice<SPI, PINS>
 where
     SPI: SpiX,
     PINS: Pins<SPI>,
 {
-    type Error = Infallible;
-
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
         WI: IntoIterator<Item = u8>,
@@ -103,14 +112,12 @@ where
     }
 }
 
-impl<SPI, PINS> Transactional<u8> for SpiExclusiveDevice<SPI, PINS>
+impl<SPI, PINS> Transactional for SpiExclusiveDevice<SPI, PINS>
 where
     SPI: SpiX,
     PINS: Pins<SPI>,
 {
-    type Error = Infallible;
-
-    fn exec<'op>(&mut self, operations: &mut [Operation<'op, u8>]) -> Result<(), Infallible> {
+    fn exec<'op>(&mut self, operations: &mut [Operation<'op, u8>]) -> Result<(), Self::Error> {
         self.bus.start_frame();
         let result = self.bus.exec(operations);
         self.bus.end_frame();

--- a/src/spi/exclusive_device.rs
+++ b/src/spi/exclusive_device.rs
@@ -1,8 +1,4 @@
-use embedded_hal::spi::{
-    blocking::{Operation, Transactional, Transfer, TransferInplace, Write, WriteIter},
-    nb::FullDuplex,
-    ErrorKind, ErrorType,
-};
+use embedded_hal::spi::{blocking::SpiDevice, ErrorKind, ErrorType};
 
 use crate::spi::SpiConfig;
 
@@ -39,89 +35,21 @@ impl<SPI, PINS> ErrorType for SpiExclusiveDevice<SPI, PINS> {
     type Error = ErrorKind;
 }
 
-impl<SPI, PINS> FullDuplex for SpiExclusiveDevice<SPI, PINS>
+impl<SPI, PINS> SpiDevice for SpiExclusiveDevice<SPI, PINS>
 where
     SPI: SpiX,
     PINS: Pins<SPI>,
 {
-    fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        self.bus.read()
-    }
+    type Bus = SpiBus<SPI, PINS>;
 
-    fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
-        self.bus.send(byte)
-    }
-}
-
-impl<SPI, PINS> Transfer for SpiExclusiveDevice<SPI, PINS>
-where
-    SPI: SpiX,
-    PINS: Pins<SPI>,
-{
-    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+    fn transaction<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self::Bus) -> Result<R, <Self::Bus as ErrorType>::Error>,
+    ) -> Result<R, Self::Error> {
         self.bus.start_frame();
-        let result = self.bus.transfer(read, write);
+        let result = f(&mut self.bus)?;
         self.bus.end_frame();
 
-        result
-    }
-}
-
-impl<SPI, PINS> TransferInplace for SpiExclusiveDevice<SPI, PINS>
-where
-    SPI: SpiX,
-    PINS: Pins<SPI>,
-{
-    fn transfer_inplace<'w>(&mut self, words: &'w mut [u8]) -> Result<(), Self::Error> {
-        self.bus.start_frame();
-        let result = self.bus.transfer_inplace(words);
-        self.bus.end_frame();
-
-        result
-    }
-}
-
-impl<SPI, PINS> Write for SpiExclusiveDevice<SPI, PINS>
-where
-    SPI: SpiX,
-    PINS: Pins<SPI>,
-{
-    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        self.bus.start_frame();
-        let result = self.bus.transfer(&mut [], words);
-        self.bus.end_frame();
-
-        result
-    }
-}
-
-impl<SPI, PINS> WriteIter for SpiExclusiveDevice<SPI, PINS>
-where
-    SPI: SpiX,
-    PINS: Pins<SPI>,
-{
-    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
-    where
-        WI: IntoIterator<Item = u8>,
-    {
-        self.bus.start_frame();
-        let result = self.bus.write_iter(words);
-        self.bus.end_frame();
-
-        result
-    }
-}
-
-impl<SPI, PINS> Transactional for SpiExclusiveDevice<SPI, PINS>
-where
-    SPI: SpiX,
-    PINS: Pins<SPI>,
-{
-    fn exec<'op>(&mut self, operations: &mut [Operation<'op, u8>]) -> Result<(), Self::Error> {
-        self.bus.start_frame();
-        let result = self.bus.exec(operations);
-        self.bus.end_frame();
-
-        result
+        Ok(result)
     }
 }

--- a/src/spi/shared_bus.rs
+++ b/src/spi/shared_bus.rs
@@ -1,5 +1,6 @@
 use core::cell::RefCell;
 use core::ops::Deref;
+use embedded_hal::spi::{ErrorKind, ErrorType};
 pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 use riscv::interrupt;
 use riscv::interrupt::Mutex;
@@ -9,6 +10,10 @@ use super::{PinCS, PinsNoCS, SpiBus, SpiConfig, SpiSharedDevice, SpiX};
 /// Newtype for RefCell<Spi> locked behind a Mutex.
 /// Used to hold the [SpiBus] instance so it can be used for multiple [SpiSharedDevice] instances.
 pub struct SharedBus<SPI, PINS>(Mutex<RefCell<SpiBus<SPI, PINS>>>);
+
+impl<SPI, PINS> ErrorType for SharedBus<SPI, PINS> {
+    type Error = ErrorKind;
+}
 
 impl<SPI, PINS> SharedBus<SPI, PINS>
 where

--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -10,7 +10,7 @@ where
 
 impl<'p, T> Write for Stdout<'p, T>
 where
-    T: embedded_hal::serial::Write<u8>,
+    T: embedded_hal::serial::nb::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         for byte in s.as_bytes() {


### PR DESCRIPTION
Adds support for embedded-hal v1.0.0-alpha.8 by refactoring existing SPI device implementation into using the new traits.

Tested with write only so far.

Requires:
https://github.com/riscv-rust/e310x/pull/26
https://github.com/rust-embedded/riscv-rt/pull/101
https://github.com/rust-embedded/riscv/pull/106

Based off of @ahmedcharles work in #42 which I kind of botched up by merging to master too soon. @ahmedcharles if you feel strongly about the contribution loss here please ping me here and we can figure out how to best combine these changes so you get the proper credit for the `alpha.7` changes.