### PR TITLE
Add PWM driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Refactored `e310x-hal::spi` module, splitting the abstraction into `SpiBus` and `SpiExclusiveDevice/SpiSharedDevice` to allow multiple devices on a single SPI bus to co-exist
+- Added Pulse Width Modulation interface implementing `embedded_hal::Pwm`
 
 ## [v0.9.4] - 2022-07-10
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod device;
 pub mod gpio;
 pub mod pmu;
 pub mod prelude;
+pub mod pwm;
 pub mod rtc;
 pub mod serial;
 pub mod spi;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1,0 +1,235 @@
+//! # Pulse Width Modulation Interface
+//!
+//! You can use the `PWM` with these [Pwm] instances
+//!
+//! # PWM0 - 8 bit period and duty
+//! - Channel 1: Pin 9 IOF1
+//! - Channel 2: Pin 10 IOF1
+//! - Channel 3: Pin 11 IOF1
+//!
+//! # PWM1 - 16 bit period and duty
+//! - Channel 1: Pin 3 IOF1
+//! - Channel 2: Pin 5 IOF1
+//! - Channel 3: Pin 6 IOF1
+//!
+//! # PWM2 - 16 bit period and duty
+//! - Channel 1: Pin 17 IOF1
+//! - Channel 2: Pin 18 IOF1
+//! - Channel 3: Pin 19 IOF1
+
+use core::marker::PhantomData;
+use core::ops::Deref;
+
+use e310x::{pwm0, PWM0, PWM1, PWM2};
+
+/// PWM comparator index
+#[derive(Copy, Clone)]
+pub enum CmpIndex {
+    /// PWM comparator 1
+    Cmp1,
+    /// PWM comparator 1
+    Cmp2,
+    /// PWM comparator 1
+    Cmp3,
+}
+
+/// PWM pin - DO NOT IMPLEMENT THIS TRAIT
+pub trait Pin<PWM> {
+    #[doc(hidden)]
+    const CMP_INDEX: CmpIndex;
+}
+
+mod pwm0_impl {
+    use super::{CmpIndex, Pin, PWM0};
+    use crate::gpio::{gpio0, NoInvert, IOF1};
+
+    impl Pin<PWM0> for gpio0::Pin1<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp1;
+    }
+
+    impl Pin<PWM0> for gpio0::Pin2<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp2;
+    }
+
+    impl Pin<PWM0> for gpio0::Pin3<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp3;
+    }
+}
+
+mod pwm1_impl {
+    use super::{CmpIndex, Pin, PWM1};
+    use crate::gpio::{gpio0, NoInvert, IOF1};
+
+    impl Pin<PWM1> for gpio0::Pin19<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp1;
+    }
+
+    impl Pin<PWM1> for gpio0::Pin21<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp2;
+    }
+
+    impl Pin<PWM1> for gpio0::Pin22<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp3;
+    }
+}
+
+mod pwm2_impl {
+    use super::{CmpIndex, Pin, PWM2};
+    use crate::gpio::{gpio0, NoInvert, IOF1};
+
+    impl Pin<PWM2> for gpio0::Pin11<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp1;
+    }
+
+    impl Pin<PWM2> for gpio0::Pin12<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp2;
+    }
+
+    impl Pin<PWM2> for gpio0::Pin13<IOF1<NoInvert>> {
+        const CMP_INDEX: CmpIndex = CmpIndex::Cmp3;
+    }
+}
+
+/// PWM channel
+pub struct Channel<PWM> {
+    _pwm: PhantomData<PWM>,
+    cmp_index: CmpIndex,
+}
+
+impl<PWM> Channel<PWM> {
+    /// Constructs a PWM channel from a PWM pin for use with [Pwm]
+    pub fn from<PIN>(_: PIN) -> Channel<PWM>
+    where
+        PIN: Pin<PWM>,
+    {
+        Channel {
+            _pwm: PhantomData,
+            cmp_index: PIN::CMP_INDEX,
+        }
+    }
+}
+
+impl<PWM> Clone for Channel<PWM> {
+    fn clone(&self) -> Self {
+        Self {
+            _pwm: self._pwm.clone(),
+            cmp_index: self.cmp_index.clone(),
+        }
+    }
+}
+
+impl<PWM> Copy for Channel<PWM> {}
+
+#[doc(hidden)]
+pub trait PwmX: Deref<Target = pwm0::RegisterBlock> {
+    type CmpWidth: Ord;
+    fn bits_from_cmp_width(other: Self::CmpWidth) -> u32;
+    fn bits_into_cmp_width(other: u32) -> Self::CmpWidth;
+}
+
+macro_rules! pwmx_impl {
+    ($PWM:ident,$CMP_WIDTH:ident) => {
+        impl PwmX for $PWM {
+            type CmpWidth = $CMP_WIDTH;
+            fn bits_from_cmp_width(other: Self::CmpWidth) -> u32 {
+                other as u32
+            }
+            fn bits_into_cmp_width(other: u32) -> Self::CmpWidth {
+                other as Self::CmpWidth
+            }
+        }
+    };
+}
+
+pwmx_impl!(PWM0, u8);
+pwmx_impl!(PWM1, u16);
+pwmx_impl!(PWM2, u16);
+
+/// PWM abstraction
+///
+/// # Notes
+///
+/// [PWM0] has a max period of 255, as it only has an 8 bit comparison register,
+/// the rest of them have a max value of 2^16 as they have 16 bit registers.
+pub struct Pwm<PWM> {
+    pwm: PWM,
+}
+
+impl<PWM: PwmX> Pwm<PWM> {
+    /// Configures a PWM device
+    pub fn new(pwm: PWM) -> Self {
+        pwm.cfg.reset();
+        pwm.cfg.write(|w| {
+            w.zerocmp()
+                .set_bit()
+                .enalways()
+                .set_bit()
+                .deglitch()
+                .set_bit()
+        });
+        pwm.cmp0.reset();
+        pwm.cmp1.reset();
+        pwm.cmp2.reset();
+        pwm.cmp3.reset();
+        Self { pwm }
+    }
+}
+
+impl<PWM: PwmX> embedded_hal::Pwm for Pwm<PWM> {
+    type Channel = Channel<PWM>;
+
+    type Time = PWM::CmpWidth;
+
+    type Duty = PWM::CmpWidth;
+
+    fn enable(&mut self, channel: Self::Channel) {
+        match channel.cmp_index {
+            CmpIndex::Cmp1 => self.pwm.cmp1.write(|w| unsafe { w.bits(u32::MAX) }),
+            CmpIndex::Cmp2 => self.pwm.cmp2.write(|w| unsafe { w.bits(u32::MAX) }),
+            CmpIndex::Cmp3 => self.pwm.cmp3.write(|w| unsafe { w.bits(u32::MAX) }),
+        }
+    }
+
+    fn disable(&mut self, channel: Self::Channel) {
+        match channel.cmp_index {
+            CmpIndex::Cmp1 => self.pwm.cmp1.reset(),
+            CmpIndex::Cmp2 => self.pwm.cmp2.reset(),
+            CmpIndex::Cmp3 => self.pwm.cmp3.reset(),
+        }
+    }
+
+    fn get_period(&self) -> Self::Time {
+        PWM::bits_into_cmp_width(self.pwm.cmp0.read().bits())
+    }
+
+    fn get_duty(&self, channel: Self::Channel) -> Self::Duty {
+        let duty = match channel.cmp_index {
+            CmpIndex::Cmp1 => self.pwm.cmp1.read().bits(),
+            CmpIndex::Cmp2 => self.pwm.cmp2.read().bits(),
+            CmpIndex::Cmp3 => self.pwm.cmp3.read().bits(),
+        };
+        PWM::bits_into_cmp_width(duty)
+    }
+
+    fn get_max_duty(&self) -> Self::Duty {
+        self.get_period()
+    }
+
+    fn set_duty(&mut self, channel: Self::Channel, duty: Self::Duty) {
+        let duty = PWM::bits_from_cmp_width(duty.min(self.get_max_duty()));
+        match channel.cmp_index {
+            CmpIndex::Cmp1 => self.pwm.cmp1.write(|w| unsafe { w.bits(duty) }),
+            CmpIndex::Cmp2 => self.pwm.cmp2.write(|w| unsafe { w.bits(duty) }),
+            CmpIndex::Cmp3 => self.pwm.cmp3.write(|w| unsafe { w.bits(duty) }),
+        }
+    }
+
+    fn set_period<P>(&mut self, period: P)
+    where
+        P: Into<Self::Time>,
+    {
+        let period = PWM::bits_from_cmp_width(period.into());
+        self.pwm.count.reset();
+        self.pwm.cmp0.write(|w| unsafe { w.bits(period) });
+    }
+}


### PR DESCRIPTION
Basic PWM implementation. Tested on Hifive1 rev 1. Should also work on rev B.

I am new to Rust and embedded hal. Let me know if this is the correct way of doing things.
References:

- [serial](https://github.com/riscv-rust/e310x-hal/blob/master/src/serial.rs) and [spi](https://github.com/riscv-rust/e310x-hal/blob/master/src/spi.rs) driver
- [SiFive manual](https://sifive.cdn.prismic.io/sifive/4faf3e34-4a42-4c2f-be9e-c77baa4928c7_fe310-g000-manual-v3p2.pdf) 
- [SiFive SDK](https://github.com/sifive/freedom-metal/blob/master/src/drivers/sifive_pwm0.c)
- [Arduino `wiring_analog`](https://github.com/sifive/cinco/blob/master/hardware/freedom_e/cores/arduino/wiring_analog.c)
- https://github.com/riscv-rust/e310x-hal/pull/32 as a reference.

Sample code that fades the green led:
```rust
    let mut pwm1 = Pwm::new(p.PWM1);
    pwm1.set_period(u16::MAX);
    let pwm1_1 = Channel::from(pin!(pins, dig3).into_iof1());

    type Duty = u16;
    const DELAY: u32 = 30;
    const INCREMENT: Duty = Duty::MAX / 51;
    let mut duty: Duty = 0;
    let mut increment = true;

    loop {
        if increment {
            duty = duty.saturating_add(INCREMENT);
        } else {
            duty = duty.saturating_sub(INCREMENT);
        }
        if duty == 0 || duty == Duty::MAX {
            increment = !increment;
        }
        pwm1.set_duty(pwm1_1, duty);
        sleep.delay_ms(DELAY);
    }
```
