### PR TITLE
use atomic-polyfill

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,17 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Install all Rust targets for ${{ matrix.rust }}
-        run: rustup target install --toolchain=${{ matrix.rust }} x86_64-unknown-linux-gnu riscv32imac-unknown-none-elf riscv64imac-unknown-none-elf riscv64gc-unknown-none-elf
+        run: rustup target install --toolchain=${{ matrix.rust }} x86_64-unknown-linux-gnu riscv32imac-unknown-none-elf riscv32imc-unknown-none-elf riscv64imac-unknown-none-elf riscv64gc-unknown-none-elf
       - name: Run CI script for riscv32imac-unknown-none-elf under ${{ matrix.rust }}
         run: |
           cargo check --target riscv32imac-unknown-none-elf
           cargo check --target riscv32imac-unknown-none-elf --features g002
           cargo check --target riscv32imac-unknown-none-elf --features virq
           cargo check --target riscv32imac-unknown-none-elf --features g002,virq
+          cargo check --target riscv32imc-unknown-none-elf
+          cargo check --target riscv32imc-unknown-none-elf --features g002
+          cargo check --target riscv32imc-unknown-none-elf --features virq
+          cargo check --target riscv32imc-unknown-none-elf --features g002,virq
 
   # On macOS and Windows, we at least make sure that the crate builds and links.
   build-other:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Use `atomic-polyfill` to allow builds on riscv32imc-unknown-none-elf targets when needed.
+
 ## [v0.10.0] - 2023-03-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.59"
 [dependencies]
 embedded-hal = { version = "0.2.6", features = ["unproven"] }
 nb = "1.0.0"
+atomic-polyfill = "1.0.2"
 riscv = { version = "0.10.1", features = ["critical-section-single-hart"] }
 e310x = { version = "0.11.0", features = ["rt", "critical-section"] }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,7 +1,7 @@
 //! General Purpose I/O
 
+use atomic_polyfill::{AtomicU32, Ordering};
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicU32, Ordering};
 
 /// GpioExt trait extends the GPIO0 peripheral.
 pub trait GpioExt {


### PR DESCRIPTION
This PR substitutes imports to `core::sync::atomic` to `atomic_polyfill`. In this way, we can now build `e310x-hal` for `riscv32imc-unknown-none-elf` targets.

The E310X board does **NOT** support the `lr` nor the `sc` atomic instructions (...). Thus, atomic functions such as `compare_exchange` trigger an exception. For those projects that use these functions (e.g., RTIC), we need to allow builds for `riscv32imc-unknown-none-elf` and let `atomic-polyfill` do the trick.