### PR TITLE
Use portable-atomic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.59.0
-        rust: [nightly, stable, 1.59.0]
+        # All generated code should be running on stable now, MRSV is 1.60.0
+        rust: [nightly, stable, 1.60.0]
 
         include:
           # Nightly is only for reference and allowed to fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Use `atomic-polyfill` to allow builds on riscv32imc-unknown-none-elf targets when needed.
+- Use `portable-atomic` to allow builds on `riscv32imc-unknown-none-elf`` targets when needed.
 
 ## [v0.10.0] - 2023-03-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ rust-version = "1.59"
 [dependencies]
 embedded-hal = { version = "0.2.6", features = ["unproven"] }
 nb = "1.0.0"
-atomic-polyfill = "1.0.2"
 riscv = { version = "0.10.1", features = ["critical-section-single-hart"] }
 e310x = { version = "0.11.0", features = ["rt", "critical-section"] }
+
+[target.'cfg(not(target_has_atomic = "32"))'.dependencies]
+portable-atomic = { version = "1.4", default-features = false, features = ["unsafe-assume-single-core"] }
 
 [features]
 g002 = ["e310x/g002"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.59.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.60.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,7 +1,11 @@
 //! General Purpose I/O
 
-use atomic_polyfill::{AtomicU32, Ordering};
 use core::marker::PhantomData;
+
+#[cfg(target_has_atomic = "32")]
+use core::sync::atomic::{AtomicU32, Ordering};
+#[cfg(not(target_has_atomic = "32"))]
+use portable_atomic::{AtomicU32, Ordering};
 
 /// GpioExt trait extends the GPIO0 peripheral.
 pub trait GpioExt {


### PR DESCRIPTION
The atomic-polyfill crate has been deprecated. Moving to portable-atomic to allow us compile for riscv32imc-unknown-none-elf targets when CAS operations are needed.