### PR TITLE
force-amo: allowing AMOxxx instructions for riscv32imc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.60.0
-        rust: [nightly, stable, 1.60.0]
+        # All generated code should be running on stable now, MRSV is 1.72.0
+        rust: [nightly, stable, 1.72.0]
 
         include:
           # Nightly is only for reference and allowed to fail

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-    "[rust]": {
-        "editor.defaultFormatter": "rust-lang.rust-analyzer",
-        "editor.formatOnSave": true
-    },
     "rust-analyzer.cargo.features": [
         "g002",
         "virq",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Use `portable-atomic` to allow builds on `riscv32imc-unknown-none-elf`` targets when needed.
+### Changed
+- Use `portable-atomic` to allow builds on `riscv32imc-unknown-none-elf` targets when needed.
+- Use `force-amo` on `portable-atomic` to use AMO instructions even when compiling for `riscv32imc-unknown-none-elf`.
+- Bump MSRV to 1.72 due to `force-amo` on `portable-atomic`.
 
 ## [v0.10.0] - 2023-03-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ categories = ["embedded", "hardware-support", "no-std"]
 description = "HAL for the E310x family of microcontrollers."
 keywords = ["riscv", "e310", "hal"]
 license = "ISC"
-edition = "2018"
-rust-version = "1.59"
+edition = "2021"
+rust-version = "1.72"
 
 [dependencies]
 embedded-hal = { version = "0.2.6", features = ["unproven"] }
@@ -17,7 +17,7 @@ riscv = { version = "0.10.1", features = ["critical-section-single-hart"] }
 e310x = { version = "0.11.0", features = ["rt", "critical-section"] }
 
 [target.'cfg(not(target_has_atomic = "32"))'.dependencies]
-portable-atomic = { version = "1.4", default-features = false, features = ["unsafe-assume-single-core"] }
+portable-atomic = { version = "1.5", default-features = false, features = ["unsafe-assume-single-core", "force-amo"] }
 
 [features]
 g002 = ["e310x/g002"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.72.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
The E310X atomic support is limited, as it only allows us to use AMO instructions, while LR/SC instructions provoke an exception. Thus, we need to provide support for `riscv32imc-unknown-none-elf` to use LR/SC instructions via `portable-atomic`. However, currently you either use emulation of all the atomic instructions or a faulty atomic target.

This PR uses a new version of `portable-atomic`, which added a new feature to use real AMO instructions for `riscv32imc-unknown-none-elf` targets while emulating LR/SC instructions. This is particularly well-suited for the E310x microcontroller. Note that the MSRV is now 1.72.

As a side note: In my opinion, this microcontroller does not deserve to be called a `riscv32imac` target. We should stop supporting `riscv32imac` and clearly document this particularity, asking users to always use `riscv32imc` with `portable-atomic` and `force-amo` when needed.